### PR TITLE
Add docker support for sg_data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+docs

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 erd.svg
 npm-debug.log
 docs/
+.nvmrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:12 as build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+COPY ./ .
+
+EXPOSE 3000
+
+FROM build as develop
+
+RUN npm install -g nodemon

--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -1,0 +1,12 @@
+version: '3.4'
+services:
+  postgres:
+    ports:
+      - "5432:5432"
+  api:
+    command: bash -c "npm run seed && nodemon --exec npm start --ignore docs/"
+    build:
+      context: .
+      target: develop
+    volumes:
+      - ./:/app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3.4'
+
+volumes:
+  sg_data_api_node_modules:
+
+services:
+  postgres:
+    container_name: sg_data_postgres
+    image: postgres
+    environment:
+      - POSTGRES_DB=sg_data
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  api:
+    container_name: sg_data_api
+    build:
+      context: .
+      target: build
+    command: bash -c "npm run seed && npm start"
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@sg_data_postgres:5432/sg_data
+    volumes:
+      - sg_data_api_node_modules:/app/node_modules
+    depends_on:
+      - postgres


### PR DESCRIPTION
Supports "production" and development mode

For development mode
- Exposed db port on 5432
- Live reloading of docs and api
- Bind mount source code
- Named volume for api node modules

Run `docker-compose -f docker-compose.yaml -f docker-compose.development.yaml <command>`
Sample commands:
- One time setup: `docker-compose -f docker-compose.yaml -f docker-compose.development.yaml build`
- Run application: `docker-compose -f docker-compose.yaml -f docker-compose.development.yaml up`
- Clean up application: `docker-compose -f docker-compose.yaml -f docker-compose.development.yaml down`

For "production" mode
- Essentially not development mode
- Named volume for api node modules

Run `docker-compose <command>`


Looking for any and all feedback, feel free to go ham